### PR TITLE
Set subnet.assignIpv6AddressOnCreation = true

### DIFF
--- a/lib/network-stack.ts
+++ b/lib/network-stack.ts
@@ -60,6 +60,7 @@ class IPv6Vpc extends ec2.Vpc {
 
       const cfnSubnet = subnet.node.defaultChild as ec2.CfnSubnet;
       cfnSubnet.ipv6CidrBlock = cidr6;
+      cfnSubnet.assignIpv6AddressOnCreation = true;  // NB: EKS-ipv6 requires this
       subnet.node.addDependency(ip6cidr);
     });
 


### PR DESCRIPTION
EKS-ipv6 requires this subnet option, but it is not strictly required for IPv6-in-VPC in general.

To keep the demo simple, just enable this option unconditionally.   A 'better' version of this class might use parameters and other fancy features.

(Completely untested! I was carried away by the github clicky-clicky editor and ran with it.)